### PR TITLE
change bower alias in QCodeDecoderAssetBundle

### DIFF
--- a/src/assets/QCodeDecoderAssetBundle.php
+++ b/src/assets/QCodeDecoderAssetBundle.php
@@ -18,7 +18,7 @@ use yii\web\AssetBundle;
  */
 class QCodeDecoderAssetBundle extends AssetBundle
 {
-    public $sourcePath = '@vendor/bower/qcode-decoder';
+    public $sourcePath = '@bower/qcode-decoder';
 
     public $js = [
         'build/qcode-decoder.min.js'


### PR DESCRIPTION
we should use @bower alias not @vendor/bower, otherwise we get in trouble when vendor/bower is moved to vendor/bower-asset.